### PR TITLE
Add disruptor related configurations

### DIFF
--- a/docs/user/configure.md
+++ b/docs/user/configure.md
@@ -29,6 +29,8 @@ These configurations are defined under the namespace `ballerina.broker.core`.
 | nonDurableQueueMaxDepth     | 10000                                  | Maximum number of messages kept in a non-durable queue. Increasing this number can increase the memory consumption. | 
 | maxPersistedChunkSize     | 65500                                  | Maximum size of a chunk that is persisted. We will have to change this value depending on the underline database used. We have used the  frame size as the limit. |
 | durableQueueInMemoryCacheLimit | 10000                                  | Maximum number of messages cached in-memory for faster delivery. Increasing this number can result in better throughput while increasing the memory consumption. |
+| disruptorBufferSize | 32768                                  | Size of the disruptor buffer used to handle message persistence asynchronously. Downside of increasing the buffer size is increased memory usage. The value should be a power of 2. E.g. 4096, 8192, 16384, 32768.|
+| maxDbWriteBatchSize | 1024                                  | Maximum number of messages in a batch when persisting messages. |
 | deliveryTask:workerCount    | 5                                      | Number of concurrent workers used to process the delivery tasks. |
 | deliveryTask:idleTaskDelay  | 50                                     | The time that the delivery task will wait when the queue is empty or no consumers are available for message delivery in milliseconds.  |
 | deliveryTask:deliveryBatchSize | 1000                                | Messages are delivered to consumers in batches by the delivery task. Following configuration changes the default message delivery batch size.

--- a/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/configuration/BrokerCoreConfiguration.java
+++ b/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/configuration/BrokerCoreConfiguration.java
@@ -44,6 +44,10 @@ public class BrokerCoreConfiguration {
 
     private String maxPersistedChunkSize = "65500";
 
+    private int disruptorBufferSize = 32768;
+
+    private int maxDbWriteBatchSize = 1024;
+
     private DeliveryTask deliveryTask = new DeliveryTask();
 
     /**
@@ -77,6 +81,28 @@ public class BrokerCoreConfiguration {
 
     public void setMaxPersistedChunkSize(String maxPersistedChunkSize) {
         this.maxPersistedChunkSize = maxPersistedChunkSize;
+    }
+
+    /**
+     * Getter for disruptorBufferSize.
+     */
+    public int getDisruptorBufferSize() {
+        return disruptorBufferSize;
+    }
+
+    public void setDisruptorBufferSize(int disruptorBufferSize) {
+        this.disruptorBufferSize = disruptorBufferSize;
+    }
+
+    /**
+     * Getter for maxDbWriteBatchSize.
+     */
+    public int getMaxDbWriteBatchSize() {
+        return maxDbWriteBatchSize;
+    }
+
+    public void setMaxDbWriteBatchSize(int maxDbWriteBatchSize) {
+        this.maxDbWriteBatchSize = maxDbWriteBatchSize;
     }
 
     /**

--- a/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/store/DbBackedStoreFactory.java
+++ b/modules/broker-core/src/main/java/io/ballerina/messaging/broker/core/store/DbBackedStoreFactory.java
@@ -46,7 +46,9 @@ public class DbBackedStoreFactory implements StoreFactory {
         daoFactory = new DaoFactory(dataSource, metricManager, configuration);
         this.metricManager = metricManager;
         this.configuration = configuration;
-        dbMessageStore = new DbMessageStore(daoFactory.createMessageDao(), 32768, 1024);
+        int disruptorBufferSize = configuration.getDisruptorBufferSize();
+        int maxDbBatchSize = configuration.getMaxDbWriteBatchSize();
+        dbMessageStore = new DbMessageStore(daoFactory.createMessageDao(), disruptorBufferSize, maxDbBatchSize);
     }
 
     @Override

--- a/modules/launcher/src/main/resources/broker.yaml
+++ b/modules/launcher/src/main/resources/broker.yaml
@@ -44,6 +44,13 @@ ballerina.broker.core:
  # used. We have used the  frame size as the limit.
  maxPersistedChunkSize: 65500
 
+ # Size of the disruptor buffer used to handle message persistence asynchronously. Downside of increasing the buffer
+ # size is increased memory usage. The value should be a power of 2. E.g. 4096, 8192, 16384, 32768.
+ disruptorBufferSize: 32768
+
+ # Maximum number of messages in a batch when persisting messages.
+ maxDbWriteBatchSize: 1024
+
  # Configuration related to message delivery task
  deliveryTask:
   # Number of concurrent workers used to process the delivery tasks.


### PR DESCRIPTION
## Purpose
We need to be able to configure the disruptor used for asynchronous message persistence. Following parameters need to be configurable.

- disruptor buffer size 
- max DB write batch size

This fixes #449

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Add related configurations to broker.yaml

## Release note
- New configurations added
 - disruptor buffer size 
 - max DB write batch size

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

Parameter descritpion added to docs/user/configure.md.

## Automation tests
 - Unit tests - 77%
 - Integration tests 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

